### PR TITLE
Add Mako 7.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
 language: php
 
 cache:
-    directories:
-        - ~/.cache/composer
+  directories:
+    - ~/.cache/composer
 
 php:
-    - 7.2
-    - 7.3
+  - 7.2
+  - 7.3
+  - 7.4
+  - nightly
 
 matrix:
-    fast_finish: true
+  allow_failures:
+    - php: nightly
+  fast_finish: true
 
 install:
-    - composer install
+  - composer install
 
 script:
-    - vendor/bin/grumphp run
+  - vendor/bin/grumphp run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,37 @@
-# 6.0
+# Changelog
 
-- Require Mako 6.0 or compatible
-- Require PHP 7.2
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Add support for Mako Framework 7. Support for Mako 6.x is unchanged.
+
+### Fixed
+
+- Fixed an issue in PHP 7.4 relating to `ReflectionType` string
+  conversion.
+
+## 6.0 - 2019-04-09
+
+### Added
+
 - TemplateCompilationTest now supports PHPUnit 6 or higher.
     - Note that this still needs PHP 7.2.
 
-# 5.2.3
+### Changed
+
+- Require Mako 6.0 or compatible
+- Require PHP 7.2
+
+## 5.2.3
+
+### Added
 
 - Add a utility template test class. Use it as a sanity check for your
   views.

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,9 @@
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2.12",
-		"phpunit/phpunit": "^8.0",
-		"phpro/grumphp": "^0.15.0",
-		"jakub-onderka/php-parallel-lint": "^1.0"
-
+		"phpunit/phpunit": "^8.0 || ^9.0",
+		"phpro/grumphp": "^0.19",
+		"php-parallel-lint/php-parallel-lint": "^1.2"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"php": "^7.2",
 		"smarty/smarty": "^3",
-		"mako/framework": "^6.0"
+		"mako/framework": "^6.0 || ^7.0"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2.12",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,16 +1,14 @@
-parameters:
-    git_dir: .
-    bin_dir: vendor/bin
-    tasks:
-        composer:
-            strict: true
-        phpcsfixer2:
-            config: .php_cs
-        phpunit: ~
-        phplint: ~
-        git_blacklist:
-            keywords:
-                - "die("
-                - "var_dump("
-                - "exit("
-            triggered_by: [php]
+grumphp:
+  tasks:
+    composer:
+      strict: true
+    phpcsfixer2:
+      config: .php_cs
+    phpunit: ~
+    phplint: ~
+    git_blacklist:
+      keywords:
+          - "die("
+          - "var_dump("
+          - "exit("
+      triggered_by: [php]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
-	bootstrap="tests/bootstrap.php"
-	colors="true"
-	backupGlobals="false"
-	verbose="true"
->
-	<testsuites>
-		<testsuite name="Unit tests">
-			<directory>tests/unit</directory>
-		</testsuite>
-	</testsuites>
-	<filter>
-		<whitelist>
-			<directory>src</directory>
-		</whitelist>
-	</filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" backupGlobals="false" verbose="true">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit tests">
+      <directory>tests/unit</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/UnresolvableParameterException.php
+++ b/src/UnresolvableParameterException.php
@@ -2,8 +2,6 @@
 
 namespace marty;
 
-use ReflectionParameter;
-
 /**
  * Thrown when parameter resolution fails and a parameter cannot be resolved.
  *
@@ -11,7 +9,7 @@ use ReflectionParameter;
  */
 class UnresolvableParameterException extends \InvalidArgumentException
 {
-    public function __construct(ReflectionParameter $parameter, \Throwable $previous = null)
+    public function __construct(\ReflectionParameter $parameter, \Throwable $previous = null)
     {
         $message = sprintf(
             'Unable to resolve parameter %s$%s (%s)',
@@ -22,8 +20,16 @@ class UnresolvableParameterException extends \InvalidArgumentException
         parent::__construct($message, 0, $previous);
     }
 
-    private function formatClassInfo(ReflectionParameter $parameter): string
+    private function formatClassInfo(\ReflectionParameter $parameter): string
     {
-        return $parameter->getType() ?? 'no type specified';
+        $type = $parameter->getType();
+
+        if ($type === null) {
+            return 'no type specified';
+        } elseif ($type instanceof \ReflectionNamedType) {
+            return $type->getName();
+        } else {
+            return 'unnamed type';
+        }
     }
 }

--- a/tests/unit/PluginLoaderTest.php
+++ b/tests/unit/PluginLoaderTest.php
@@ -27,7 +27,7 @@ class PluginLoaderTest extends TestCase
                 $this->anything(),
                 $this->anything(),
                 $this->callback('is_callable')
-        );
+            );
 
         $instance = new PluginLoader(new ParameterResolver($container));
         $dirs     = [dirname(__DIR__).'/resources/plugins'];


### PR DESCRIPTION
As the title says. The plugin structure appears to have kept backwards compatibility, so support for previous versions doesn't have to be dropped.