### PR TITLE
Fix php 8 deprecation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Marty is a simple Smarty view renderer for the Mako framework.
 
 Marty has been tested on all current Mako versions. Any other version
 _may_ work, but has not been tested. Unit tests are run against PHP 7.0
-and up. Smarty 3 is required, but will be pulled in as part of the
+and up. Smarty 3 or 4 is required, but will be pulled in as part of the
 installation.
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	],
 	"require": {
 		"php": "^7.2 || ^8.0",
-		"smarty/smarty": "^3",
+		"smarty/smarty": "^3 || ^4",
 		"mako/framework": "^6.0 || ^7.0 || ^8.0"
 	},
 	"require-dev": {

--- a/src/ParameterResolver.php
+++ b/src/ParameterResolver.php
@@ -43,12 +43,12 @@ class ParameterResolver
     private function resolveDIParameter(ReflectionParameter $parameter)
     {
         try {
-            $class = $parameter->getClass();
-            if ($class == null) {
+            $type = $parameter->getType();
+            if ($type == null) {
                 throw new UnresolvableParameterException($parameter);
             }
 
-            return $this->container->get($class->getName());
+            return $this->container->get($type->getName());
         } catch (\Throwable $ex) {
             throw new UnresolvableParameterException($parameter, $ex);
         }


### PR DESCRIPTION
Marty and Smarty show some deprecation errors when used in php 8. So I fixed all deprecated functions in Marty and made it possible to update Smarty to version 4.

This was originally reviewed in pr #6, but to make the codebase cleaner everything is now rebased into a single commit. (Didn't find a way to do so without making a new branch, so sorry for the new PR)